### PR TITLE
Padding for `base64.b64decodestring` changed into `b'==='`.

### DIFF
--- a/stegano/tools.py
+++ b/stegano/tools.py
@@ -107,9 +107,7 @@ def base642binary(b64_fname):
     #b64_str = fin.read()
     #fin.close()
     # Decode base64 string to original binary sound object
-    missing_padding = 4 - len(b64_fname) % 4
-    if missing_padding:
-        b64_fname += b'='* missing_padding
+    b64_fname += b'==='
     return base64.decodestring(b64_fname)
 
     #return base64.b64decode(b64_fname)


### PR DESCRIPTION
Fixes #6