### PR TITLE
Exif image format on save

### DIFF
--- a/tests/test_exifHeader.py
+++ b/tests/test_exifHeader.py
@@ -86,7 +86,7 @@ class TestEXIFHeader(unittest.TestCase):
     def test_with_bytes(self):
         outputBytes = io.BytesIO()
         message = b"Secret"
-        exifHeader.hide("./tests/sample-files/20160505T130442.jpg",
+        exifHeader.hide(open("./tests/sample-files/20160505T130442.jpg", 'rb'),
                             outputBytes,
                             secret_message=message)
 

--- a/tests/test_exifHeader.py
+++ b/tests/test_exifHeader.py
@@ -26,6 +26,7 @@ __license__ = "GPLv3"
 
 import os
 import unittest
+import io
 
 from stegano import exifHeader
 
@@ -81,6 +82,16 @@ class TestEXIFHeader(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             clear_message = exifHeader.reveal("./image.png")
+
+    def test_with_bytes(self):
+        outputBytes = io.BytesIO()
+        message = b"Secret"
+        exifHeader.hide("./tests/sample-files/20160505T130442.jpg",
+                            outputBytes,
+                            secret_message=message)
+
+        clean_message = exifHeader.reveal(outputBytes)
+        self.assertEqual(message, clean_message)
 
     def tearDown(self):
         try:


### PR DESCRIPTION
If the image data is coming via byte streams, e.g., ByteIO, then we have a problem with the `exifHeader.reveal()` and `exifHeader.hide()` method because they assumes either a `string` filename for the image arguments.

Fix for `exifHeader.hide()`:

The `Image.save()` call needs to know the image format of `img_enc`. Typically it can guess if the first argument is a string filename. If not then one must pass the image format via `format=FORMAT` argument. This can be auto-guessed directly from `img`, which is what happens in this PR, but I've also added an optional argument to the `hide()` method signature.

Fix for `exifHeader.reveal()`:

`piexif.load()` is not as flexible as `Image.open()` in that it can only cope with input being a string filename or the raw exif bytes. Passing a byte stream is not supported. Therefore one must first load `input_image_file` via `Image.open()` and then extract the exif as normal. In order to keep backward compatibility I throw the ValueError if the format is not JPG or TIF.  
