### PR TITLE
Fix ResourceWarning: unclosed file, in tests

### DIFF
--- a/tests/test_exifHeader.py
+++ b/tests/test_exifHeader.py
@@ -86,12 +86,11 @@ class TestEXIFHeader(unittest.TestCase):
     def test_with_bytes(self):
         outputBytes = io.BytesIO()
         message = b"Secret"
-        exifHeader.hide(open("./tests/sample-files/20160505T130442.jpg", 'rb'),
-                            outputBytes,
-                            secret_message=message)
+        with open("./tests/sample-files/20160505T130442.jpg", 'rb') as f:
+            exifHeader.hide(f, outputBytes, secret_message=message)
 
-        clear_message = exifHeader.reveal(outputBytes)
-        self.assertEqual(message, clear_message)
+            clear_message = exifHeader.reveal(outputBytes)
+            self.assertEqual(message, clear_message)
 
     def tearDown(self):
         try:

--- a/tests/test_lsb.py
+++ b/tests/test_lsb.py
@@ -134,13 +134,14 @@ class TestLSB(unittest.TestCase):
         for message in messages_to_hide:
             message = "Hello World"
             outputBytes = io.BytesIO()
-            bytes_image = lsb.hide(open("./tests/sample-files/20160505T130442.jpg", 'rb'), message)
-            bytes_image.save(outputBytes, "PNG")
-            outputBytes.seek(0)
+            with open("./tests/sample-files/20160505T130442.jpg", 'rb') as f:
+                bytes_image = lsb.hide(f, message)
+                bytes_image.save(outputBytes, "PNG")
+                outputBytes.seek(0)
 
-            clear_message = lsb.reveal(outputBytes)
+                clear_message = lsb.reveal(outputBytes)
 
-            self.assertEqual(message, clear_message)
+                self.assertEqual(message, clear_message)
 
     def tearDown(self):
         try:


### PR DESCRIPTION
Fixes 2 warnings in tests:
```python
test_lsb.py:137 unclosed file <_io.BufferedReader name='./tests/sample-files/20160505T130442.jpg'>"
test_exifHeader.py:91 unclosed file <_io.BufferedReader name='./tests/sample-files/20160505T130442.jpg'>"
```