### PR TITLE
new: add reversible data hiding via histogram shifting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Release History
 
+### Unreleased
+
+- Added a reversible data hiding technique based on histogram shifting
+  (`stegano.rdh`), with a `stegano-rdh` command line tool. Unlike LSB, the
+  original cover image can be recovered exactly after the message is
+  extracted.
+
+
 ### 2.4.1 (2026-03-27)
 
 - Optimized red channel `hide()` and `reveal()` to stop iterating after the

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
 
 
 - Alexander Treml - https://github.com/AlexanderTreml
+- Eesh Saxena - https://github.com/eeshsaxena
 - Adrien Cosson - https://cosson.io
 - Andrew Roberts <andy.roberts.uk@gmail.com>
 - Christophe Goessen - https://github.com/cgoessen

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ appropriate steganography technique. For example:
 >>> clear_message = lsb.reveal("./Lenna-secret.png")
 ```
 
+For *reversible* data hiding (the original cover can be restored exactly after
+the message is extracted), use the histogram-shifting technique:
+
+```python
+>>> from stegano import rdh
+>>> secret = rdh.hide("./tests/sample-files/Lenna-grayscale.png", "Hello World")
+>>> secret.save("./Lenna-secret.png")
+>>>
+>>> clear_message = rdh.reveal("./Lenna-secret.png")
+>>> cover = rdh.recover("./Lenna-secret.png")  # restores the original image
+```
+
 
 ## Use Stegano as a command line tool
 
@@ -58,6 +70,15 @@ appropriate steganography technique. For example:
 $ stegano-lsb hide -i ./tests/sample-files/Lenna.png -m "Secret Message" -o Lena1.png
 $ stegano-lsb reveal -i Lena1.png
 Secret Message
+```
+
+### Reversibly hide a message and recover the cover
+
+```bash
+$ stegano-rdh hide -i ./tests/sample-files/Lenna-grayscale.png -m "Secret Message" -o stego.png
+$ stegano-rdh reveal -i stego.png
+Secret Message
+$ stegano-rdh recover -i stego.png -o cover.png   # cover.png == the original image
 ```
 
 

--- a/docs/module.rst
+++ b/docs/module.rst
@@ -105,6 +105,37 @@ Sets are used in order to select the pixels where the message will be hidden.
 
 
 
+Reversible data hiding (histogram shifting)
+-------------------------------------------
+
+Unlike the LSB technique, histogram shifting is *reversible*: once the message
+has been extracted, the original cover image can be reconstructed
+pixel-for-pixel with ``recover()``. It implements the method of Ni et al.,
+*Reversible data hiding*, IEEE TCSVT, 2006.
+
+.. code-block:: python
+
+    Python 3.11.0 (main, Oct 31 2022, 15:15:22) [GCC 12.2.0] on linux
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>> from stegano import rdh
+    >>> secret = rdh.hide("./tests/sample-files/Lenna-grayscale.png", "Hello world!")
+    >>> secret.save("./Lenna-secret.png")
+    >>> print(rdh.reveal("./Lenna-secret.png"))
+    Hello world!
+
+    # The original cover is recovered exactly.
+    >>> from PIL import Image
+    >>> original = Image.open("./tests/sample-files/Lenna-grayscale.png").convert("L")
+    >>> recovered = rdh.recover("./Lenna-secret.png")
+    >>> recovered.tobytes() == original.tobytes()
+    True
+
+    # How many bytes fit in a given cover.
+    >>> rdh.capacity("./tests/sample-files/Lenna-grayscale.png")
+    303
+
+
+
 Description field of the image
 ------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ Documentation = "https://stegano.readthedocs.io"
 
 [project.scripts]
 stegano-lsb = "stegano.console.lsb:main"
+stegano-rdh = "stegano.console.rdh:main"
 stegano-red = "stegano.console.red:main"
 stegano-steganalysis-parity = "stegano.console.parity:main"
 stegano-steganalysis-statistics = "stegano.console.statistics:main"

--- a/stegano/__init__.py
+++ b/stegano/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 
-from . import exifHeader, lsb, red, steganalysis
+from . import exifHeader, lsb, rdh, red, steganalysis
 
-__all__ = ["red", "exifHeader", "lsb", "steganalysis"]
+__all__ = ["red", "exifHeader", "lsb", "rdh", "steganalysis"]

--- a/stegano/console/rdh.py
+++ b/stegano/console/rdh.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+# Stegano - Stegano is a pure Python steganography module.
+# Copyright (C) 2010-2026 Cédric Bonhomme - https://www.cedricbonhomme.org
+#
+# For more information : https://github.com/cedricbonhomme/Stegano
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+__author__ = "Eesh Saxena"
+__license__ = "GPLv3"
+
+import argparse
+
+from stegano import rdh, tools
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="stegano-rdh")
+    subparsers = parser.add_subparsers(
+        help="sub-command help", dest="command", required=True
+    )
+
+    # Subparser: Hide
+    parser_hide = subparsers.add_parser(
+        "hide", help="Hide a message with histogram shifting."
+    )
+    parser_hide.add_argument(
+        "-i",
+        "--input",
+        dest="input_image_file",
+        required=True,
+        help="Input (cover) image file.",
+    )
+    parser_hide.add_argument(
+        "-e",
+        "--encoding",
+        dest="encoding",
+        choices=tools.ENCODINGS.keys(),
+        default="UTF-8",
+        help="Encoding of the message to hide. UTF-8 (default) or UTF-32LE.",
+    )
+    parser_hide.add_argument(
+        "-m",
+        dest="secret_message",
+        required=True,
+        help="Your secret message to hide.",
+    )
+    parser_hide.add_argument(
+        "-o",
+        "--output",
+        dest="output_image_file",
+        required=True,
+        help="Output image containing the secret.",
+    )
+
+    # Subparser: Reveal
+    parser_reveal = subparsers.add_parser("reveal", help="Reveal a hidden message.")
+    parser_reveal.add_argument(
+        "-i",
+        "--input",
+        dest="input_image_file",
+        required=True,
+        help="Input image file.",
+    )
+    parser_reveal.add_argument(
+        "-e",
+        "--encoding",
+        dest="encoding",
+        choices=tools.ENCODINGS.keys(),
+        default="UTF-8",
+        help="Encoding of the message to reveal. UTF-8 (default) or UTF-32LE.",
+    )
+
+    # Subparser: Recover
+    parser_recover = subparsers.add_parser(
+        "recover", help="Losslessly recover the original cover image."
+    )
+    parser_recover.add_argument(
+        "-i",
+        "--input",
+        dest="input_image_file",
+        required=True,
+        help="Input stego image file.",
+    )
+    parser_recover.add_argument(
+        "-o",
+        "--output",
+        dest="output_image_file",
+        required=True,
+        help="Output file for the recovered cover image.",
+    )
+
+    arguments = parser.parse_args()
+
+    if arguments.command == "hide":
+        stego = rdh.hide(
+            arguments.input_image_file,
+            arguments.secret_message,
+            arguments.encoding,
+        )
+        stego.save(arguments.output_image_file)
+    elif arguments.command == "reveal":
+        print(rdh.reveal(arguments.input_image_file, arguments.encoding))
+    elif arguments.command == "recover":
+        recovered = rdh.recover(arguments.input_image_file)
+        recovered.save(arguments.output_image_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/stegano/rdh/__init__.py
+++ b/stegano/rdh/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+from .histogram_shifting import capacity, hide, recover, reveal
+
+__all__ = ["capacity", "hide", "recover", "reveal"]

--- a/stegano/rdh/histogram_shifting.py
+++ b/stegano/rdh/histogram_shifting.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python
+# Stegano - Stegano is a pure Python steganography module.
+# Copyright (C) 2010-2026  Cédric Bonhomme - https://www.cedricbonhomme.org
+#
+# For more information : https://github.com/cedricbonhomme/Stegano
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+"""Reversible data hiding using histogram shifting.
+
+Unlike the LSB technique, this is a *reversible* (a.k.a. lossless) data
+hiding scheme: after the secret message is extracted, the original cover
+image can be reconstructed pixel-for-pixel. This is useful when the cover
+must not be permanently altered, for example medical, military or legal
+imagery.
+
+The scheme is the histogram-shifting method of
+
+    Z. Ni, Y.-Q. Shi, N. Ansari and W. Su, "Reversible data hiding,"
+    IEEE Transactions on Circuits and Systems for Video Technology,
+    vol. 16, no. 3, pp. 354-362, 2006. doi:10.1109/TCSVT.2006.869964
+
+Given the histogram of the (single 8-bit channel) sample values, a *peak*
+point ``p`` (the most frequent value) and a *zero* point ``z`` (a value that
+does not occur) are selected. All samples strictly between ``p`` and ``z``
+are shifted by one towards ``z``, which frees the bin next to the peak. The
+message is then embedded at the peak: a sample equal to ``p`` is left
+untouched to encode a ``0`` and moved to the freed bin to encode a ``1``.
+Extraction reverses both steps, so the cover image is fully restored.
+
+Because ``p`` and ``z`` (and the payload length) are needed to extract and
+to invert the shift, they are written into a small self-describing header
+that occupies the least-significant bits of the first samples. The original
+bits of those samples are themselves carried in the reversible payload, so
+the header costs nothing in terms of reversibility.
+"""
+
+from typing import IO, List, Tuple, Union
+
+from PIL import Image
+
+from stegano import tools
+
+__author__ = "Eesh Saxena"
+__license__ = "GPLv3"
+
+# 16-bit magic ("RD") + peak (8) + zero (8) + payload length (32).
+_MAGIC = 0x5244
+_HEADER_BITS = 16 + 8 + 8 + 32
+
+
+def _flatten(image: Image.Image) -> List[int]:
+    """Return the image samples as a flat list of ints.
+
+    Every 8-bit sample (channel-interleaved for multi-band images) becomes an
+    independent element of the returned list, so histogram shifting can treat
+    an ``L``, ``RGB`` or ``RGBA`` image uniformly.
+    """
+    samples = list(image.tobytes())
+    if not samples:
+        raise ValueError("Cannot hide data in an empty image.")
+    return samples
+
+
+def _unflatten(samples: List[int], image: Image.Image) -> Image.Image:
+    """Rebuild an image of the same mode/size from a flat list of samples."""
+    return Image.frombytes(image.mode, image.size, bytes(samples))
+
+
+def _int_to_bits(value: int, length: int) -> List[int]:
+    return [(value >> (length - 1 - i)) & 1 for i in range(length)]
+
+
+def _bits_to_int(bits: List[int]) -> int:
+    value = 0
+    for bit in bits:
+        value = (value << 1) | bit
+    return value
+
+
+def _select_peak_zero(samples: List[int]) -> Tuple[int, int]:
+    """Pick the peak (most frequent) and zero (absent) sample values.
+
+    The zero point closest to the peak is chosen, which minimises the number
+    of shifted samples and therefore the distortion.
+    """
+    histogram = [0] * 256
+    for value in samples:
+        histogram[value] += 1
+
+    peak = max(range(256), key=lambda v: histogram[v])
+
+    zero = None
+    best_distance = 257
+    for value in range(256):
+        if histogram[value] == 0 and abs(value - peak) < best_distance:
+            zero = value
+            best_distance = abs(value - peak)
+    if zero is None:
+        raise ValueError(
+            "The image histogram is fully saturated (every value in 0-255 "
+            "occurs), so histogram-shifting has no zero point to use. Try an "
+            "image with a less busy histogram."
+        )
+    return peak, zero
+
+
+def _peak_capacity(samples: List[int], peak: int) -> int:
+    return samples.count(peak)
+
+
+def _embed_into_payload(
+    payload: List[int], bits: List[int], peak: int, zero: int
+) -> List[int]:
+    """Shift the payload samples and embed ``bits`` at the peak."""
+    direction = 1 if peak < zero else -1
+    companion = peak + direction
+    low, high = (peak, zero) if peak < zero else (zero, peak)
+
+    result = []
+    bit_iter = iter(bits)
+    for sample in payload:
+        if low < sample < high:
+            # Make room next to the peak by shifting towards the zero point.
+            result.append(sample + direction)
+        elif sample == peak:
+            try:
+                bit = next(bit_iter)
+            except StopIteration:
+                result.append(peak)
+            else:
+                result.append(companion if bit else peak)
+        else:
+            result.append(sample)
+    return result
+
+
+def _extract_from_payload(
+    payload: List[int], peak: int, zero: int, length: int
+) -> Tuple[List[int], List[int]]:
+    """Extract ``length`` bits and restore the original payload samples."""
+    direction = 1 if peak < zero else -1
+    companion = peak + direction
+
+    bits: List[int] = []
+    restored = []
+    for sample in payload:
+        if len(bits) < length and sample in (peak, companion):
+            bits.append(0 if sample == peak else 1)
+        if direction == 1:
+            restored.append(sample - 1 if peak < sample <= zero else sample)
+        else:
+            restored.append(sample + 1 if zero <= sample < peak else sample)
+    return bits, restored
+
+
+def capacity(image: Union[str, IO[bytes], Image.Image]) -> int:
+    """Return the maximum message size, in bytes, for ``image``.
+
+    This is the size of the histogram peak minus the fixed header overhead.
+    """
+    img = tools.open_image(image)
+    samples = _flatten(img)
+    payload = samples[_HEADER_BITS:]
+    if not payload:
+        return 0
+    peak, _zero = _select_peak_zero(payload)
+    usable_bits = _peak_capacity(payload, peak) - _HEADER_BITS
+    return max(usable_bits, 0) // 8
+
+
+def hide(
+    image: Union[str, IO[bytes], Image.Image],
+    message: str,
+    encoding: str = "UTF-8",
+) -> Image.Image:
+    """Hide ``message`` reversibly in ``image`` using histogram shifting.
+
+    Returns a new :class:`PIL.Image.Image`. The original cover can later be
+    recovered exactly with :func:`recover`.
+    """
+    img = tools.open_image(image)
+    if img.mode not in ("L", "RGB", "RGBA"):
+        raise ValueError(
+            f"Unsupported image mode {img.mode!r}; use 'L', 'RGB' or 'RGBA'."
+        )
+
+    samples = _flatten(img)
+    if len(samples) <= _HEADER_BITS:
+        raise ValueError("Image is too small to hold the header.")
+
+    header_region = samples[:_HEADER_BITS]
+    payload_region = samples[_HEADER_BITS:]
+
+    peak, zero = _select_peak_zero(payload_region)
+
+    message_bits = [
+        int(bit) for byte in tools.a2bits_list(message, encoding) for bit in byte
+    ]
+    # The payload also carries the original LSBs of the header samples, so the
+    # header we overwrite below is itself reversible.
+    saved_header_lsbs = [sample & 1 for sample in header_region]
+    full_payload = saved_header_lsbs + message_bits
+
+    available = _peak_capacity(payload_region, peak)
+    if len(full_payload) > available:
+        max_message_bits = max(available - _HEADER_BITS, 0)
+        raise ValueError(
+            "Message is too long for this image: capacity is "
+            f"{max_message_bits // 8} bytes, message needs "
+            f"{len(message_bits) // 8} bytes."
+        )
+
+    embedded_payload = _embed_into_payload(payload_region, full_payload, peak, zero)
+
+    # Write the self-describing header into the LSBs of the first samples.
+    header_bits: List[int] = []
+    header_bits += _int_to_bits(_MAGIC, 16)
+    header_bits += _int_to_bits(peak, 8)
+    header_bits += _int_to_bits(zero, 8)
+    header_bits += _int_to_bits(len(full_payload), 32)
+    new_header = [
+        tools.setlsb(sample, str(bit))
+        for sample, bit in zip(header_region, header_bits)
+    ]
+
+    return _unflatten(new_header + embedded_payload, img)
+
+
+def reveal(image: Union[str, IO[bytes], Image.Image], encoding: str = "UTF-8") -> str:
+    """Extract the message hidden in ``image`` by :func:`hide`."""
+    img = tools.open_image(image)
+    samples = _flatten(img)
+    header_bits = [sample & 1 for sample in samples[:_HEADER_BITS]]
+    if _bits_to_int(header_bits[:16]) != _MAGIC:
+        raise ValueError("No histogram-shifting payload found in this image.")
+    peak = _bits_to_int(header_bits[16:24])
+    zero = _bits_to_int(header_bits[24:32])
+    length = _bits_to_int(header_bits[32:64])
+
+    payload_bits, _restored = _extract_from_payload(
+        samples[_HEADER_BITS:], peak, zero, length
+    )
+    message_bits = payload_bits[_HEADER_BITS:]
+
+    byte_size = tools.ENCODINGS[encoding]
+    characters = []
+    for i in range(0, len(message_bits) - byte_size + 1, byte_size):
+        characters.append(chr(_bits_to_int(message_bits[i : i + byte_size])))
+    return "".join(characters)
+
+
+def recover(image: Union[str, IO[bytes], Image.Image]) -> Image.Image:
+    """Reconstruct the original cover image from a stego image.
+
+    Returns an image identical, pixel-for-pixel, to the cover passed to
+    :func:`hide`.
+    """
+    img = tools.open_image(image)
+    samples = _flatten(img)
+    header_bits = [sample & 1 for sample in samples[:_HEADER_BITS]]
+    if _bits_to_int(header_bits[:16]) != _MAGIC:
+        raise ValueError("No histogram-shifting payload found in this image.")
+    peak = _bits_to_int(header_bits[16:24])
+    zero = _bits_to_int(header_bits[24:32])
+    length = _bits_to_int(header_bits[32:64])
+
+    payload_bits, restored_payload = _extract_from_payload(
+        samples[_HEADER_BITS:], peak, zero, length
+    )
+    saved_header_lsbs = payload_bits[:_HEADER_BITS]
+    restored_header = [
+        tools.setlsb(sample, str(bit))
+        for sample, bit in zip(samples[:_HEADER_BITS], saved_header_lsbs)
+    ]
+    return _unflatten(restored_header + restored_payload, img)

--- a/stegano/rdh/histogram_shifting.py
+++ b/stegano/rdh/histogram_shifting.py
@@ -165,12 +165,20 @@ def _extract_from_payload(
     return bits, restored
 
 
+def _check_mode(image: Image.Image) -> None:
+    if image.mode not in ("L", "RGB", "RGBA"):
+        raise ValueError(
+            f"Unsupported image mode {image.mode!r}; use 'L', 'RGB' or 'RGBA'."
+        )
+
+
 def capacity(image: Union[str, IO[bytes], Image.Image]) -> int:
     """Return the maximum message size, in bytes, for ``image``.
 
     This is the size of the histogram peak minus the fixed header overhead.
     """
     img = tools.open_image(image)
+    _check_mode(img)
     samples = _flatten(img)
     payload = samples[_HEADER_BITS:]
     if not payload:
@@ -191,10 +199,7 @@ def hide(
     recovered exactly with :func:`recover`.
     """
     img = tools.open_image(image)
-    if img.mode not in ("L", "RGB", "RGBA"):
-        raise ValueError(
-            f"Unsupported image mode {img.mode!r}; use 'L', 'RGB' or 'RGBA'."
-        )
+    _check_mode(img)
     if encoding == "UTF-8" and any(ord(char) > 255 for char in message):
         raise ValueError(
             "The message contains characters that do not fit in one byte "

--- a/stegano/rdh/histogram_shifting.py
+++ b/stegano/rdh/histogram_shifting.py
@@ -195,6 +195,11 @@ def hide(
         raise ValueError(
             f"Unsupported image mode {img.mode!r}; use 'L', 'RGB' or 'RGBA'."
         )
+    if encoding == "UTF-8" and any(ord(char) > 255 for char in message):
+        raise ValueError(
+            "The message contains characters that do not fit in one byte "
+            "with the UTF-8 encoding; use the UTF-32LE encoding instead."
+        )
 
     samples = _flatten(img)
     if len(samples) <= _HEADER_BITS:

--- a/tests/test_rdh.py
+++ b/tests/test_rdh.py
@@ -104,6 +104,8 @@ class TestHistogramShifting(unittest.TestCase):
     def test_unsupported_mode_raises(self):
         with self.assertRaises(ValueError):
             rdh.hide(Image.new("CMYK", (64, 64)), "hi")
+        with self.assertRaises(ValueError):
+            rdh.capacity(Image.new("CMYK", (64, 64)))
 
     def test_saturated_histogram_raises(self):
         # An image whose payload region uses every value in 0-255 has no zero

--- a/tests/test_rdh.py
+++ b/tests/test_rdh.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# Stegano - Stegano is a pure Python steganography module.
+# Copyright (C) 2010-2026  Cédric Bonhomme - https://www.cedricbonhomme.org
+#
+# For more information : https://github.com/cedricbonhomme/Stegano
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+import os
+import unittest
+
+from PIL import Image
+
+from stegano import rdh
+
+GRAYSCALE = "./tests/sample-files/Lenna-grayscale.png"
+COLOR = "./tests/sample-files/Lenna.png"
+
+
+class TestHistogramShifting(unittest.TestCase):
+    def tearDown(self):
+        for name in ("./rdh-stego.png",):
+            if os.path.isfile(name):
+                os.unlink(name)
+
+    def test_hide_and_reveal(self):
+        messages = ["a", "foo", "Hello World!", ":Python:", ""]
+        for message in messages:
+            stego = rdh.hide(GRAYSCALE, message)
+            stego.save("./rdh-stego.png")
+            self.assertEqual(message, rdh.reveal("./rdh-stego.png"))
+
+    def test_hide_and_reveal_rgb(self):
+        message = "Reversible data hiding in an RGB image."
+        stego = rdh.hide(COLOR, message)
+        stego.save("./rdh-stego.png")
+        self.assertEqual(message, rdh.reveal("./rdh-stego.png"))
+
+    def test_cover_is_recovered_exactly_grayscale(self):
+        # The defining property of reversible data hiding: after extraction
+        # the original cover is restored pixel-for-pixel.
+        original = Image.open(GRAYSCALE).convert("L")
+        stego = rdh.hide(original, "some secret payload")
+        recovered = rdh.recover(stego)
+        self.assertEqual(recovered.mode, original.mode)
+        self.assertEqual(recovered.size, original.size)
+        self.assertEqual(recovered.tobytes(), original.tobytes())
+
+    def test_cover_is_recovered_exactly_rgb(self):
+        original = Image.open(COLOR).convert("RGB")
+        stego = rdh.hide(original, "another secret payload for rgb")
+        recovered = rdh.recover(stego)
+        self.assertEqual(recovered.tobytes(), original.tobytes())
+
+    def test_recovery_survives_lossless_save(self):
+        original = Image.open(GRAYSCALE).convert("L")
+        rdh.hide(original, "persisted secret").save("./rdh-stego.png")
+        self.assertEqual("persisted secret", rdh.reveal("./rdh-stego.png"))
+        recovered = rdh.recover("./rdh-stego.png")
+        self.assertEqual(recovered.tobytes(), original.tobytes())
+
+    def test_stego_only_differs_by_at_most_one_level(self):
+        # Histogram shifting only ever moves a sample by +/-1.
+        original = Image.open(GRAYSCALE).convert("L")
+        stego = rdh.hide(original, "low distortion check")
+        for before, after in zip(original.tobytes(), stego.tobytes()):
+            self.assertLessEqual(abs(before - after), 1)
+
+    def test_capacity_matches_hide_limit(self):
+        capacity = rdh.capacity(GRAYSCALE)
+        self.assertGreater(capacity, 0)
+        # A message at the capacity fits; one byte more does not.
+        rdh.hide(GRAYSCALE, "a" * capacity)
+        with self.assertRaises(ValueError):
+            rdh.hide(GRAYSCALE, "a" * (capacity + 1))
+
+    def test_reveal_without_payload_raises(self):
+        with self.assertRaises(ValueError):
+            rdh.reveal(GRAYSCALE)
+
+    def test_unsupported_mode_raises(self):
+        with self.assertRaises(ValueError):
+            rdh.hide(Image.new("CMYK", (64, 64)), "hi")
+
+    def test_saturated_histogram_raises(self):
+        # An image whose payload region uses every value in 0-255 has no zero
+        # point for the shift.
+        saturated = Image.new("L", (256, 256))
+        saturated.putdata([i % 256 for i in range(256 * 256)])
+        with self.assertRaises(ValueError):
+            rdh.hide(saturated, "hi")
+
+    def test_image_too_small_raises(self):
+        with self.assertRaises(ValueError):
+            rdh.hide(Image.new("L", (4, 4)), "hi")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rdh.py
+++ b/tests/test_rdh.py
@@ -47,6 +47,18 @@ class TestHistogramShifting(unittest.TestCase):
         stego.save("./rdh-stego.png")
         self.assertEqual(message, rdh.reveal("./rdh-stego.png"))
 
+    def test_hide_and_reveal_utf32le(self):
+        message = "héllo €"
+        stego = rdh.hide(GRAYSCALE, message, "UTF-32LE")
+        stego.save("./rdh-stego.png")
+        self.assertEqual(message, rdh.reveal("./rdh-stego.png", "UTF-32LE"))
+
+    def test_wide_characters_rejected_with_utf8(self):
+        # Characters above U+00FF do not fit in the 8 bits per character of
+        # the UTF-8 encoding and would be silently corrupted.
+        with self.assertRaises(ValueError):
+            rdh.hide(GRAYSCALE, "héllo €")
+
     def test_cover_is_recovered_exactly_grayscale(self):
         # The defining property of reversible data hiding: after extraction
         # the original cover is restored pixel-for-pixel.


### PR DESCRIPTION
## Summary

This adds a **reversible data hiding** technique to Stegano, based on the
histogram-shifting scheme of

> Z. Ni, Y.-Q. Shi, N. Ansari and W. Su, "Reversible data hiding," *IEEE
> Transactions on Circuits and Systems for Video Technology*, vol. 16, no. 3,
> pp. 354-362, 2006. [doi:10.1109/TCSVT.2006.869964](https://doi.org/10.1109/TCSVT.2006.869964)

Unlike the existing techniques (LSB, red channel, ...), which alter the cover
image permanently, reversible data hiding lets the receiver **reconstruct the
original cover pixel-for-pixel** after extracting the message. That property
matters for medical, military and legal imagery, where the carrier must not be
degraded.

## How it works

Given the histogram of the 8-bit samples, a *peak* value `p` (most frequent)
and a *zero* value `z` (absent) are chosen. Samples strictly between `p` and
`z` are shifted by one towards `z`, freeing the bin next to the peak; the
message is then embedded at the peak (`p` -> stays for a `0`, moves to the
freed bin for a `1`). `reveal()` / `recover()` invert both steps.

`p`, `z` and the payload length are stored in a small self-describing header in
the LSBs of the first samples, whose original bits are themselves carried in
the reversible payload, so extraction needs no side channel and the header
costs nothing in reversibility. Grayscale (`L`), `RGB` and `RGBA` images are
supported.

## API

```python
>>> from stegano import rdh
>>> stego = rdh.hide("./tests/sample-files/Lenna-grayscale.png", "Hello World")
>>> stego.save("./stego.png")
>>> rdh.reveal("./stego.png")
'Hello World'
>>> cover = rdh.recover("./stego.png")   # original image, restored exactly
>>> rdh.capacity("./tests/sample-files/Lenna-grayscale.png")   # bytes
303
```

A `stegano-rdh` command line tool (`hide` / `reveal` / `recover`) is included,
mirroring `stegano-lsb`.

## What's included

- `stegano/rdh/` - the technique (`hide`, `reveal`, `recover`, `capacity`),
  pure Python, no new dependencies.
- `stegano/console/rdh.py` + a `stegano-rdh` entry point.
- `tests/test_rdh.py` - 11 tests: hide/reveal roundtrips (grayscale + RGB),
  **pixel-exact cover recovery**, survival of a lossless save, the +/-1
  distortion bound, capacity limits, and the error paths (message too long,
  unsupported mode, no payload, saturated histogram, image too small).
- Docs (`README.md`, `docs/module.rst`), `CHANGELOG.md`, `CONTRIBUTORS.md`.

## Verification

`pytest` - 62 passed (11 new, no regressions). `black`, `isort`, `flake8` and
`mypy` are clean for the new files. On the bundled Lenna images the stego PSNR
is ~53 dB and the recovered cover matches the original byte-for-byte.

## Notes / limitations

- Reversibility requires a lossless container (PNG etc.); a JPEG save would
  destroy the payload, as with the other pixel-based techniques.
- The basic scheme needs one empty histogram bin in the payload region; a
  fully saturated histogram raises a clear `ValueError`. Multi-peak embedding
  for higher capacity would be a natural follow-up.
