### PR TITLE
Fix Unicode corruption in LSB and wav steganography (new byte-based format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## Release History
 
+### Unreleased
+
+- Fixed silent corruption of LSB messages containing Unicode code points
+  above U+00FF (emoji, CJK, accented characters, etc.) with the UTF-8
+  encoding: the message is now embedded as its encoded bytes instead of
+  8-bit truncated code points
+  ([~cedric/stegano#4](https://todo.sr.ht/~cedric/stegano/4)).
+  Thanks to ~lechynte.
+- **Breaking change**: the on-image LSB format changed. Images hidden with
+  Stegano <= 2.5.0 can only be revealed by this version if they contain
+  pure ASCII text with the UTF-8 encoding (that case is bit-identical).
+  Non-ASCII UTF-8 messages and all UTF-32LE messages use a different bit
+  layout and must be hidden again with the new version.
+
+
 ### 2.5.0 (2026-07-10)
 
 - Added a reversible data hiding technique based on histogram shifting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@
   pure ASCII text with the UTF-8 encoding (that case is bit-identical).
   Non-ASCII UTF-8 messages and all UTF-32LE messages use a different bit
   layout and must be hidden again with the new version.
+- Fixed the same Unicode corruption in the wav module: the message is now
+  embedded as its encoded bytes, and the 8-bit length prefix stores the
+  length of the message in bytes (up to 255) instead of characters.
+- Fixed the wav module modifying the least significant bit of every *byte*
+  of the frame data instead of every sample. On 16-bit PCM carriers this
+  changed sample amplitudes by up to ±257 (clearly audible and trivially
+  detectable); samples now change by at most ±1.
+- **Breaking change**: because of the two fixes above, the wav bit layout
+  changed as well. Messages hidden in WAV files with Stegano <= 2.5.0 can
+  only be revealed by this version if the message is pure ASCII with the
+  UTF-8 encoding *and* the carrier uses 8-bit samples; anything else must
+  be hidden again with the new version.
 
 
 ### 2.5.0 (2026-07-10)

--- a/docs/software.rst
+++ b/docs/software.rst
@@ -79,7 +79,7 @@ Specify an encoding
 .. code-block:: bash
 
     $ stegano-lsb hide -i ./tests/sample-files/Lenna.png -m 'I love 🍕 and 🍫.' -e UTF-32LE -o ./Lenna_enc.png
-    $ stegano-lsb reveal -i ./Lenna_enc.png
+    $ stegano-lsb reveal -i ./Lenna_enc.png -e UTF-32LE
     I love 🍕 and 🍫.
 
 The default encoding is UTF-8.

--- a/stegano/tools.py
+++ b/stegano/tools.py
@@ -124,6 +124,9 @@ class Hider:
     ):
         self._index = 0
 
+        if encoding not in ENCODINGS:
+            raise ValueError(f"Unsupported encoding: {encoding}")
+
         message_length = len(message)
         assert message_length != 0, "message length is zero"
 
@@ -145,8 +148,13 @@ class Hider:
         self._is_rgba = self.encoded_image.mode == "RGBA"
         self._pixels = self.encoded_image.load()
 
-        message = str(message_length) + ":" + str(message)
-        self._message_bits = "".join(a2bits_list(message, encoding))
+        # The payload is the byte-length prefix "<n>:" followed by the
+        # message encoded to bytes, 8 bits per byte.
+        message_bytes = message.encode(encoding)
+        prefix_bytes = (str(len(message_bytes)) + ":").encode("ascii")
+        self._message_bits = "".join(
+            bin(byte)[2:].rjust(8, "0") for byte in prefix_bytes + message_bytes
+        )
         self._message_bits += "0" * ((3 - (len(self._message_bits) % 3)) % 3)
 
         width, height = self.encoded_image.size
@@ -155,7 +163,8 @@ class Hider:
 
         if self._len_message_bits > npixels * 3:
             raise Exception(
-                f"The message you want to hide is too long: {message_length}"
+                f"The message you want to hide is too long: "
+                f"{len(message_bytes)} bytes"
             )
 
     def encode_another_pixel(self):
@@ -191,10 +200,13 @@ class Revealer:
         encoding: str = "UTF-8",
         close_file: bool = True,
     ):
+        if encoding not in ENCODINGS:
+            raise ValueError(f"Unsupported encoding: {encoding}")
+
         self.encoded_image = open_image(encoded_image)
-        self._encoding_length = ENCODINGS[encoding]
+        self._encoding = encoding
         self._buff, self._count = 0, 0
-        self._bitab: List[str] = []
+        self._bitab: List[int] = []
         self._limit: Union[None, int] = None
         self._limit_str = ""  # Accumulator for length prefix to avoid O(n²) joins
         self.secret_message = ""
@@ -215,27 +227,32 @@ class Revealer:
             pixel = pixel[:3]  # ignore the alpha
 
         for color in pixel:
-            self._buff += (color & 1) << (self._encoding_length - 1 - self._count)
+            self._buff += (color & 1) << (7 - self._count)
             self._count += 1
 
-            if self._count == self._encoding_length:
-                char = chr(self._buff)
-                self._bitab.append(char)
+            if self._count == 8:
+                byte = self._buff
+                self._bitab.append(byte)
                 self._buff, self._count = 0, 0
 
                 # Accumulate length prefix incrementally to avoid O(n²) joins
                 if self._limit is None:
-                    if char == ":":
+                    if byte == ord(":"):
                         if self._limit_str.isdigit():
                             self._limit = int(self._limit_str)
                         else:
                             raise IndexError("Impossible to detect message.")
                     else:
-                        self._limit_str += char
+                        self._limit_str += chr(byte)
 
         prefix_len = len(str(self._limit)) + 1
         if len(self._bitab) - prefix_len == self._limit:
-            self.secret_message = "".join(self._bitab)[prefix_len:]
+            try:
+                self.secret_message = bytes(self._bitab[prefix_len:]).decode(
+                    self._encoding
+                )
+            except UnicodeDecodeError as exc:
+                raise IndexError("Impossible to detect message.") from exc
             if self.close_file:
                 self.encoded_image.close()
             return True

--- a/stegano/wav/wav.py
+++ b/stegano/wav/wav.py
@@ -38,12 +38,15 @@ def hide(
     """
     Hide a message (string) in a .wav audio file.
 
-    Use the lsb of each PCM encoded sample to hide the message string characters as ASCII values.
-    The first eight bits are used for message_length of the string.
+    Use the LSB of each PCM encoded sample to hide the message bytes.
+    The first eight bits are used for the length of the message in bytes.
     """
-    message_length = len(message)
-    assert message_length != 0, "message message_length is zero"
-    assert message_length < 255, "message is too long"
+    if encoding not in tools.ENCODINGS:
+        raise ValueError(f"Unsupported encoding: {encoding}")
+
+    assert len(message) != 0, "message message_length is zero"
+    message_bytes = message.encode(encoding)
+    assert len(message_bytes) < 256, "message is too long"
 
     output = wave.open(output_file, "wb")
     with wave.open(input_file, "rb") as input:
@@ -53,8 +56,11 @@ def hide(
 
         nsamples = nframes * nchannels
 
-        message_bits = f"{message_length:08b}" + "".join(
-            tools.a2bits_list(message, encoding)
+        # The payload is the byte-length prefix (8 bits) followed by the
+        # message encoded to bytes, 8 bits per byte.
+        message_bits = "".join(
+            bin(byte)[2:].rjust(8, "0")
+            for byte in bytes([len(message_bytes)]) + message_bytes
         )
         assert len(message_bits) <= nsamples, "message is too long"
 
@@ -63,14 +69,14 @@ def hide(
         output.setsampwidth(sampwidth)
         output.setframerate(framerate)
 
-        # encode message in frames
-        frames = bytearray(input.readframes(nsamples))
-        for i in range(nsamples):
-            if i < len(message_bits):
-                if message_bits[i] == "0":
-                    frames[i] = frames[i] & ~1
-                else:
-                    frames[i] = frames[i] | 1
+        # Encode one bit per sample. PCM samples wider than one byte are
+        # little-endian: the LSB of sample i is bit 0 of frames[i * sampwidth].
+        frames = bytearray(input.readframes(nframes))
+        for i, bit in enumerate(message_bits):
+            if bit == "0":
+                frames[i * sampwidth] = frames[i * sampwidth] & ~1
+            else:
+                frames[i * sampwidth] = frames[i * sampwidth] | 1
 
         # write out
         output.writeframes(frames)
@@ -78,35 +84,35 @@ def hide(
 
 def reveal(input_file: Union[str, IO[bytes]], encoding: str = "UTF-8"):
     """
-    Find a message in an image.
+    Find a message in a .wav audio file.
 
-    Check the lsb of each PCM encoded sample for hidden message characters (ASCII values).
-    The first eight bits are used for message_length of the string.
+    Check the LSB of each PCM encoded sample for the hidden message bytes.
+    The first eight bits are used for the length of the message in bytes.
     """
-    message = ""
-    encoding_len = tools.ENCODINGS[encoding]
+    if encoding not in tools.ENCODINGS:
+        raise ValueError(f"Unsupported encoding: {encoding}")
+
     with wave.open(input_file, "rb") as input:
-        nchannels, _, _, nframes, comptype, _ = input.getparams()
+        _, sampwidth, _, nframes, comptype, _ = input.getparams()
         assert comptype == "NONE", "only uncompressed files are supported"
 
-        nsamples = nframes * nchannels
-        frames = bytearray(input.readframes(nsamples))
+        frames = bytearray(input.readframes(nframes))
 
-        # Read first 8 bits for message length
+        # Read first 8 bits for the message length in bytes
         length_bits = ""
         for i in range(8):
-            length_bits += str(frames[i] & 1)
+            length_bits += str(frames[i * sampwidth] & 1)
         message_length = int(length_bits, 2)
 
-        # Read message bits
-        message_bits = ""
-        for i in range(8, 8 + message_length * encoding_len):
-            message_bits += str(frames[i] & 1)
+        # Read the message bytes
+        message_bytes = bytearray()
+        for i in range(message_length):
+            byte_bits = ""
+            for j in range(8):
+                byte_bits += str(frames[(8 + i * 8 + j) * sampwidth] & 1)
+            message_bytes.append(int(byte_bits, 2))
 
-        # Convert bits to string
-        chars = [
-            chr(int(message_bits[i : i + encoding_len], 2))
-            for i in range(0, len(message_bits), encoding_len)
-        ]
-        message = "".join(chars)
-    return message
+    try:
+        return bytes(message_bytes).decode(encoding)
+    except UnicodeDecodeError as exc:
+        raise IndexError("Impossible to detect message.") from exc

--- a/tests/test_lsb.py
+++ b/tests/test_lsb.py
@@ -145,6 +145,53 @@ class TestLSB(unittest.TestCase):
         )
         self.assertEqual(messages_to_hide, clear_message)
 
+    def test_hide_and_reveal_UTF8_unicode(self):
+        messages_to_hide = ["héllo wörld 🔥", "🍕🍕🍕", "café crème", "こんにちは"]
+        for message in messages_to_hide:
+            secret = lsb.hide("./tests/sample-files/Lenna.png", message)
+            secret.save("./image.png")
+
+            clear_message = lsb.reveal("./image.png")
+
+            self.assertEqual(message, clear_message)
+
+    def test_on_image_format(self):
+        """
+        The on-image format is "<byte length>:" followed by the message
+        encoded to bytes, 8 bits per byte, one bit per colour component.
+        """
+        message = "héllo 🔥"
+        message_bytes = message.encode("UTF-8")
+        expected = str(len(message_bytes)).encode("ascii") + b":" + message_bytes
+
+        secret = lsb.hide("./tests/sample-files/Lenna.png", message)
+
+        width = secret.width
+        pixels = secret.load()
+        bits = []
+        for index in range((len(expected) * 8 + 2) // 3):
+            r, g, b = pixels[index % width, index // width][:3]
+            bits += [r & 1, g & 1, b & 1]
+        decoded = bytes(
+            int("".join(map(str, bits[i : i + 8])), 2)
+            for i in range(0, len(expected) * 8, 8)
+        )
+
+        self.assertEqual(decoded, expected)
+
+    def test_with_unsupported_encoding(self):
+        with self.assertRaises(ValueError):
+            lsb.hide("./tests/sample-files/Lenna.png", "Hello", encoding="latin-1")
+        with self.assertRaises(ValueError):
+            lsb.reveal("./tests/sample-files/Lenna.png", encoding="latin-1")
+
+    def test_reveal_with_wrong_encoding(self):
+        secret = lsb.hide("./tests/sample-files/Lenna.png", "🍕", encoding="UTF-32LE")
+        secret.save("./image.png")
+
+        with self.assertRaises(IndexError):
+            lsb.reveal("./image.png")
+
     def test_with_transparent_png(self):
         messages_to_hide = ["a", "foo", "Hello World!", ":Python:"]
         for message in messages_to_hide:

--- a/tests/test_wav.py
+++ b/tests/test_wav.py
@@ -22,8 +22,10 @@ __version__ = "$Revision: 0.1 $"
 __date__ = "$Date: 2016/05/19 $"
 __license__ = "GPLv3"
 
+import array
 import os
 import unittest
+import wave
 
 from stegano import wav
 
@@ -47,9 +49,73 @@ class TestWav(unittest.TestCase):
 
             self.assertEqual(message, clear_message)
 
+    def test_hide_and_reveal_UTF8_unicode(self):
+        messages_to_hide = ["héllo wörld 🔥", "🍕🍕🍕", "café crème"]
+
+        for message in messages_to_hide:
+            wav.hide(
+                "./tests/sample-files/free-software-song.wav", message, "./audio.wav"
+            )
+            clear_message = wav.reveal("./audio.wav")
+
+            self.assertEqual(message, clear_message)
+
+    def test_hide_and_reveal_UTF32LE(self):
+        message = "I love 🍕 and 🍫!"
+        wav.hide(
+            "./tests/sample-files/free-software-song.wav",
+            message,
+            "./audio.wav",
+            encoding="UTF-32LE",
+        )
+        clear_message = wav.reveal("./audio.wav", encoding="UTF-32LE")
+
+        self.assertEqual(message, clear_message)
+
+    def test_sample_distortion(self):
+        """
+        Hiding a message must only change the least significant bit of the
+        samples: on a 16-bit carrier every sample may change by at most 1.
+        """
+        wav.hide(
+            "./tests/sample-files/free-software-song.wav",
+            "Hello World!",
+            "./audio.wav",
+        )
+
+        with wave.open("./tests/sample-files/free-software-song.wav", "rb") as f:
+            original = array.array("h", f.readframes(f.getnframes()))
+        with wave.open("./audio.wav", "rb") as f:
+            encoded = array.array("h", f.readframes(f.getnframes()))
+
+        max_delta = max(abs(a - b) for a, b in zip(original, encoded))
+        self.assertLessEqual(max_delta, 1)
+
+    def test_with_unsupported_encoding(self):
+        with self.assertRaises(ValueError):
+            wav.hide(
+                "./tests/sample-files/free-software-song.wav",
+                "Hello",
+                "./audio.wav",
+                encoding="latin-1",
+            )
+        with self.assertRaises(ValueError):
+            wav.reveal(
+                "./tests/sample-files/free-software-song.wav", encoding="latin-1"
+            )
+
     def test_with_too_long_message(self):
         with open("./tests/sample-files/lorem_ipsum.txt") as f:
             message = f.read()
+        with self.assertRaises(AssertionError):
+            wav.hide(
+                "./tests/sample-files/free-software-song.wav", message, "./audio.wav"
+            )
+
+    def test_with_message_over_byte_limit(self):
+        # 64 four-byte characters exceed the 255-byte capacity of the
+        # 8-bit length prefix even though the character count is small.
+        message = "🔥" * 64
         with self.assertRaises(AssertionError):
             wav.hide(
                 "./tests/sample-files/free-software-song.wav", message, "./audio.wav"


### PR DESCRIPTION
## Summary

Two commits that fix silent Unicode corruption by switching the hidden-message format to encoded bytes, plus a wav-specific embedding fix. Closes #72.

### `fix: [lsb] embed messages as encoded bytes to fix Unicode corruption`

Amended version of the patch contributed by ~lechynte on [sourcehut ticket ~cedric/stegano#4](https://todo.sr.ht/~cedric/stegano/4) (original author credit preserved). `hide()` converted each character to a fixed-width bit string via `ord()`; with UTF-8 (8 bits) any code point above U+00FF overflows (`rjust` does not truncate), so `"héllo wörld 🔥"` revealed as `'héllo wörld ú'`. The message is now embedded as `"<byte length>:"` + its encoded bytes, 8 bits per byte.

Amendments on top of the original patch: encoding-name validation (`ValueError`), decode failures re-raised as the documented `IndexError`, byte-based "too long" error, four new tests (round-trip, on-image format pinning, error paths), changelog entry, and a docs fix (the UTF-32LE reveal example was missing `-e`).

### `fix: [wav] embed message bytes in the true LSB of each sample` (#72)

1. Same Unicode corruption as above (`"🔥🔥🔥"` → `'ú\x92ý'`); the 8-bit length prefix now stores the byte count (max 255 bytes).
2. Bits were written to the LSB of every *byte* of frame data, ignoring `sampwidth` — on 16-bit PCM this changed sample amplitudes by up to ±257 (audible, trivially detectable). Bits now go only to the least significant byte of each little-endian sample; measured max sample delta dropped from 257 to 1.

Five new tests, including a distortion regression test asserting max delta ≤ 1 on the 16-bit sample carrier.

## Breaking change (documented in CHANGELOG)

The on-image/on-file bit layout changed. Payloads hidden with Stegano ≤ 2.5.0 remain readable only if pure ASCII with UTF-8 (bit-identical) — and, for WAV, only with 8-bit carriers. Everything else must be hidden again. Both breaks land together so the format only changes once; a major version bump may be warranted.

## Test plan

- [x] `python -m unittest discover -v` — 73 tests, all passing
- [x] `mypy stegano` — same 6 pre-existing errors as master
- [x] `pre-commit run --all-files` — clean
- [x] Cross-version compatibility matrix (hide with 2.5.0 / reveal with this branch and vice versa) verified empirically; results match the compatibility statement above
- [x] Ticket repros verified: LSB emoji round-trip, wav emoji round-trip, wav 16-bit sample delta ≤ 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)